### PR TITLE
Explain the basics of cs config, link to detailed instructions

### DIFF
--- a/src/docs/deployments/setup/DOC.md
+++ b/src/docs/deployments/setup/DOC.md
@@ -61,6 +61,7 @@ Travis-CI should be enabled for your dev repo
 14. For a description of which branches route to which environments, please see the [insights-frontend-starter-app README.md](https://github.com/RedHatInsights/insights-frontend-starter-app/)
 
 ## Configuring Your App in cloud-services-config
+
 We've added a new [global configuration](https://github.com/RedHatInsights/cloud-services-config/blob/master/main.yml) that acts as the main source of truth.
 This file controls the routing for prod (Akamai), the file management and routing for non-prod (fakamai, assets-puller, assets-server), smoke tests, chrome navigation, and more.
 To add your app and enable it on all environments, please create a PR with the changes described [here](https://github.com/RedHatInsights/cloud-services-config#adding-config-for-new-apps).

--- a/src/docs/deployments/setup/DOC.md
+++ b/src/docs/deployments/setup/DOC.md
@@ -63,4 +63,4 @@ Travis-CI should be enabled for your dev repo
 ## Configuring Your App in cloud-services-config
 We've added a new [global configuration](https://github.com/RedHatInsights/cloud-services-config/blob/master/main.yml) that acts as the main source of truth.
 This file controls the routing for prod (Akamai), the file management and routing for non-prod (fakamai, assets-puller, assets-server), smoke tests, chrome navigation, and more.
-To add your app and enable it on all environments, please create a PR with the changes described [here](https://github.com/RedHatInsights/cloud-services-config/tree/enhancements/doc#adding-config-for-new-apps).
+To add your app and enable it on all environments, please create a PR with the changes described [here](https://github.com/RedHatInsights/cloud-services-config#adding-config-for-new-apps).

--- a/src/docs/deployments/setup/DOC.md
+++ b/src/docs/deployments/setup/DOC.md
@@ -2,7 +2,7 @@
 
 The deployment process for the applications on the Insights Platform uses an Akamai NetStorage instance to store all of the files that are used to render the pages for production and a similar setup for CI and QA. To get the files there we use a travis-ci script to push the build files to a build Github repo whenever master or a deployment branch is pushed. Jenkins watches the build repo and kicks off a job that will then sync the build files with our NetStorage or pre-prod environments.
 
-## Setting up with Travis-CI:
+## Setting up Continuous Integration with Travis-CI:
 
 ### Prerequisite:
 
@@ -10,7 +10,7 @@ Your project repo should be public
 Travis CLI: `gem install travis` or `brew install travis`
 Travis-CI should be enabled for your dev repo
 
-## Steps
+### Steps
 
 1. Copy the travis.yml file, the .travis directory, and the config directory from the Insights Frontend Starter App and place in the root of your project
     * Make sure the files inside the .travis folder are executables (chmod +x foo.sh)
@@ -59,3 +59,8 @@ Travis-CI should be enabled for your dev repo
 13. Confirm the build completed successfully on Travis-CI and verify that the files were pushed to your build repo’s ci-beta branch.
 
 14. For a description of which branches route to which environments, please see the [insights-frontend-starter-app README.md](https://github.com/RedHatInsights/insights-frontend-starter-app/)
+
+## Configuring Your App in cloud-services-config
+We've added a new [global configuration](https://github.com/RedHatInsights/cloud-services-config/blob/master/main.yml) that acts as the main source of truth.
+This file controls the routing for prod (Akamai), the file management and routing for non-prod (fakamai, assets-puller, assets-server), smoke tests, chrome navigation, and more.
+To add your app and enable it on all environments, please create a PR with the changes described [here](https://github.com/RedHatInsights/cloud-services-config/tree/enhancements/doc#adding-config-for-new-apps).


### PR DESCRIPTION
I just wanted to make a section in the deployments section of Storybook going over what cloud-services-config does, and saying that you have to set up your app there in order for it to show in our environments.
It links to the README in the cloud-services-config repo, which goes into more detail about how to configure an app.

I don't want to explain the step-by-step instructions in the Storybook (yet), since it still feels like some of the config structure could change at any moment. I'm open to going into more detail on this page once we've given the dust a little time to settle.