### PR TITLE
Add blurb about symlink to python2

### DIFF
--- a/src/docs/welcome/quickStart/DOC.md
+++ b/src/docs/welcome/quickStart/DOC.md
@@ -6,6 +6,7 @@
 
 1. Make sure you have node, npm, and git installed on your machine
 2. If you haven't yet, set up an ssh key for Github. [Docs](https://help.github.com/en/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)
+3. **OSX users only** Should you encounter an error during exe of a `run.sh` script stating `python2: command not found`, then you'll need to create a symlink back to python2.7 like so: `sudo ln -s /usr/bin/python2.7 /usr/local/bin/python2`
 
 ### Docker
 
@@ -96,6 +97,7 @@ Bootstrapped application with essential tools for rapid development
     ```sh
     SPANDX_CONFIG=path/to/insights-frontend-starter-app/config/spandx.config.js sh path/to/insights-proxy/scripts/run.sh
     ```
+   - NOTE: if you get a `python2: command not found` error here, then you'll need to create a symlink back to python2.7 like so: `sudo ln -s /usr/bin/python2.7 /usr/local/bin/python2`
 
 ### Starter App
 

--- a/src/docs/welcome/quickStart/DOC.md
+++ b/src/docs/welcome/quickStart/DOC.md
@@ -97,7 +97,8 @@ Bootstrapped application with essential tools for rapid development
     ```sh
     SPANDX_CONFIG=path/to/insights-frontend-starter-app/config/spandx.config.js sh path/to/insights-proxy/scripts/run.sh
     ```
-   - NOTE: if you get a `python2: command not found` error here, then you'll need to create a symlink back to python2.7 like so: `sudo ln -s /usr/bin/python2.7 /usr/local/bin/python2`
+
+   * NOTE: if you get a `python2: command not found` error here, then you'll need to create a symlink back to python2.7 like so: `sudo ln -s /usr/bin/python2.7 /usr/local/bin/python2`
 
 ### Starter App
 


### PR DESCRIPTION
While running thru the quick start guide, I ran into python2 errors that were resolved with a symlink created in /usr/local/bin. Updating the Storybook to reflect this.

<img width="1246" alt="Image 2019-09-23 at 1 47 25 PM" src="https://user-images.githubusercontent.com/10932980/65449457-07e48700-de09-11e9-8dac-21fcc9706ad6.png">

<img width="1133" alt="Image 2019-09-23 at 1 47 14 PM" src="https://user-images.githubusercontent.com/10932980/65449478-129f1c00-de09-11e9-9322-659bf810c027.png">
